### PR TITLE
Configure standalone output and update Docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,13 @@ RUN npm prune --omit=dev
 FROM base
 
 # Copy built application
-COPY --from=build /app /app
+COPY --from=build /app/.next/standalone /app
+COPY --from=build /app/.next/static /app/.next/static
+COPY --from=build /app/public /app/public
 
 # Entrypoint sets up the container.
 ENTRYPOINT [ "/app/docker-entrypoint.js" ]
 
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000
-CMD [ "npm", "run", "start" ]
+CMD [ "node", "server.js" ]

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+    output: "standalone"
 };
 
 export default nextConfig;


### PR DESCRIPTION
- Added `output: "standalone"` to next.config.ts for optimized builds
- Updated Dockerfile to copy standalone files and use `node server.js` as entrypoint