### PR TITLE
Update fly.io VM memory to 512MB

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -17,7 +17,7 @@ primary_region = 'ord'
   processes = ['app']
 
 [[vm]]
-  memory = '1gb'
+  memory = '512mb'
   cpu_kind = 'shared'
   cpus = 1
-  memory_mb = 1024
+  memory_mb = 512


### PR DESCRIPTION
No additional description needed.