### PR TITLE
Update Fly.io VM configuration to shared-cpu-1x with 256MB memory

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -6,18 +6,15 @@
 app = 'lonely-cat'
 primary_region = 'ord'
 
-[build]
-
 [http_service]
   internal_port = 3000
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
   min_machines_running = 0
-  processes = ['app']
 
 [[vm]]
-  memory = '512mb'
-  cpu_kind = 'shared'
+  size = 'shared-cpu-1x'
+  memory = '256mb'
   cpus = 1
-  memory_mb = 512
+  cpu_kind = 'shared'


### PR DESCRIPTION
This pull request updates the Fly.io VM configuration to use the `shared-cpu-1x` instance type with 256MB of memory. This change aims to optimize resource usage and potentially reduce costs while maintaining application performance.